### PR TITLE
Fixed VAT calculation

### DIFF
--- a/income-calculator.js
+++ b/income-calculator.js
@@ -129,7 +129,7 @@ var IncomeCalculator = function() {
   };
 
   this.vatTax = function(info) {
-    return info.netIncome * this.VAT;
+    return info.netIncome * this.VAT / (1 + this.VAT);
   };
 
   this.workingForSelf = function(info) {

--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
   <div class="footnotes">
     <div class="container">
       <div class="col-md-6 col-md-offset-3">
-        <h6>Approximations are based on VAT and personal income tax as per the 2016 budget. VAT has been assumed at a level of 14% of disposable income.</h6>
+        <h6>Approximations are based on VAT and personal income tax as per the 2016 budget. VAT calculation assumes all disposable income is spent on standard rated (14%) items.</h6>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This is an urgent fix. The calculation included a beginner mistake with regards to accounting for VAT. If you spend R10k, R10k \* 0.14 / 1.14 is the amount of VAT that you spent, not R10k \* 0.14 as we have currently been using.
